### PR TITLE
fix password handling in registration form

### DIFF
--- a/php/register.php
+++ b/php/register.php
@@ -17,7 +17,7 @@
         $accountData = getPasswortByUsername($_POST['usernameNew']);
 
         if($accountData['userId'] == NULL) {
-            if(createNeuenAccount($_POST['usernameNew'], $accountData['passwort'], $_POST['emailNew'], $_POST['birthdayNew'])) {
+            if(createNeuenAccount($_POST['usernameNew'], $_POST['passwordNew'], $_POST['emailNew'], $_POST['birthdayNew'])) {
                 header("Location: ../login.php?newAccount=" . $_POST['usernameNew']);
             } else {
                 echo "Fehler beim erstellen des neuen Nutzers, probiere es noch einmal.";


### PR DESCRIPTION
**Bug**: new user registration does not pass the new password to the database (empty instead)

**Solution**: change empty account data element to correct form data element